### PR TITLE
fix: update pytest and remove pytest-cov

### DIFF
--- a/tests/unit/test_dbt_clean.py
+++ b/tests/unit/test_dbt_clean.py
@@ -11,7 +11,7 @@ def test_dbt_clean():
             b"stderr",
         )
         mock_popen.return_value.returncode = 0
-        result = main()
+        result = main(argv=[])
         assert result == 0
 
 
@@ -22,7 +22,7 @@ def test_dbt_clean_error():
             b"stderr",
         )
         mock_popen.return_value.returncode = 1
-        result = main()
+        result = main(argv=[])
         assert result == 1
 
 

--- a/tests/unit/test_dbt_deps.py
+++ b/tests/unit/test_dbt_deps.py
@@ -11,7 +11,7 @@ def test_dbt_deps():
             b"stderr",
         )
         mock_popen.return_value.returncode = 0
-        result = main()
+        result = main(argv=[])
         assert result == 0
 
 
@@ -22,7 +22,7 @@ def test_dbt_deps_error():
             b"stderr",
         )
         mock_popen.return_value.returncode = 1
-        result = main()
+        result = main(argv=[])
         assert result == 1
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
     pip install -e .
     pytest
 
+
 [testenv:pre-commit]
 passenv =
     LC_ALL

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ commands =
     pip install -e .
     pytest
 
-
 [testenv:pre-commit]
 passenv =
     LC_ALL

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps = -r{toxinidir}/requirements-dev.txt
 skip_install = true
 commands =
     pip install -e .
-    pytest --cov=dbt_gloss {posargs:tests}
+    pytest
 
 [testenv:pre-commit]
 passenv =


### PR DESCRIPTION
Temporarily remove pytest-cov testing while repo is being updated. After python 3.10 is added, we'll re-add pytest-cov and calibrate per python version the level of testing coverage to be expected. 