### PR TITLE
chore: update pre-commit-config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "image": "python:3.8.12-slim",
 
   // Set *default* container specific settings.json values on container create.
-  "settings": { 
+  "settings": {
     "python.pythonPath": "/usr/local/bin/python",
     "python.defaultInterpreterPath": "/usr/local/bin/python",
     "python.languageServer": "Pylance"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,37 @@
 repos:
--   repo: https://github.com/psf/black
-    rev: 20.8b1
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
       - id: black
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-docstring-first
-    -   id: check-added-large-files
-    -   id: debug-statements
-    -   id: name-tests-test
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-docstring-first
+      - id: check-added-large-files
+      - id: debug-statements
+      - id: name-tests-test
         args: ['--django']
--   repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:
-    -   id: flake8
+      - id: flake8
         additional_dependencies:
           - flake8-absolute-import
           - flake8-black
           - flake8-comprehensions
--   repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.6
+  - repo: https://github.com/asottile/reorder_python_imports
+    rev: v3.9.0
     hooks:
-    -   id: reorder-python-imports
+      - id: reorder-python-imports
         args: [--py3-plus]
--   repo: https://github.com/asottile/setup-cfg-fmt
+  - repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.16.0
     hooks:
-    -   id: setup-cfg-fmt
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+      - id: setup-cfg-fmt
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.982
     hooks:
-    -   id: mypy
+      - id: mypy
+        additional_dependencies: [types-PyYAML]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -122,7 +122,7 @@
     description: Ensures the source has a specific number (max/min) of childs.
     entry: check-source-childs
     language: python
-    types: [sql]  
+    types: [sql]
 -   id: check-source-columns-have-desc
     name: Check for source column descriptions
     description: Ensures that the source has columns with descriptions in the properties file.

--- a/dbt_gloss/generate_missing_sources.py
+++ b/dbt_gloss/generate_missing_sources.py
@@ -5,7 +5,8 @@ from typing import FrozenSet
 from typing import Optional
 from typing import Sequence
 
-import yaml
+from yaml import dump
+from yaml import safe_load
 
 from dbt_gloss.check_script_ref_and_source import check_refs_sources
 from dbt_gloss.utils import add_filenames_args
@@ -26,7 +27,7 @@ def create_missing_sources(
             path = Path(output_path)
             # is file and exists
             if path.is_file():
-                schema = yaml.safe_load(path.open())
+                schema = safe_load(path.open())
                 schema_sources = schema.get("sources", [])
                 seen = False  # pragma: no mutate
                 for schema_source in schema_sources:
@@ -42,7 +43,7 @@ def create_missing_sources(
                     )
                 with open(path, "w") as f:
                     print(f"Generating missing source `{source_name}.{table_name}`.")
-                    yaml.dump(schema, f, default_flow_style=False, sort_keys=False)
+                    dump(schema, f, default_flow_style=False, sort_keys=False)
             else:
                 print(
                     f"Path `{output_path}` does not exists. "

--- a/dbt_gloss/generate_model_properties_file.py
+++ b/dbt_gloss/generate_model_properties_file.py
@@ -2,11 +2,11 @@ import argparse
 from pathlib import Path
 from typing import Any
 from typing import Dict
-from typing import NoReturn
 from typing import Optional
 from typing import Sequence
 
-import yaml
+from yaml import dump
+from yaml import safe_load
 
 from dbt_gloss.utils import add_catalog_args
 from dbt_gloss.utils import add_filenames_args
@@ -18,8 +18,8 @@ from dbt_gloss.utils import JsonOpenError
 from dbt_gloss.utils import Model
 
 
-def append_to_properties_file(path: Path, model_schema: Dict[str, Any]) -> NoReturn:
-    file = yaml.safe_load(path.open())
+def append_to_properties_file(path: Path, model_schema: Dict[str, Any]) -> None:
+    file = safe_load(path.open())
     if file.get("models"):
         model = file.get("models")
     else:
@@ -28,18 +28,18 @@ def append_to_properties_file(path: Path, model_schema: Dict[str, Any]) -> NoRet
     model.append(model_schema)
     model_name = model_schema.get("name")  # pragma: no mutate
     with open(path, "w") as f:
-        yaml.dump(file, f, default_flow_style=False, sort_keys=False)
+        dump(file, f, default_flow_style=False, sort_keys=False)
         print(
             f"{path}: the schema of the `{model_name}` model was appended to the file."
         )
 
 
-def write_to_properties_file(path: Path, model_schema: Dict[str, Any]) -> NoReturn:
+def write_to_properties_file(path: Path, model_schema: Dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     file = {"version": 2, "models": [model_schema]}
     model_name = model_schema.get("name")  # pragma: no mutate
     with open(path, "w") as f:
-        yaml.dump(file, f, default_flow_style=False, sort_keys=False)
+        dump(file, f, default_flow_style=False, sort_keys=False)
         print(
             f"{path}: the schema of the `{model_name}` model was written to the file."
         )
@@ -47,7 +47,7 @@ def write_to_properties_file(path: Path, model_schema: Dict[str, Any]) -> NoRetu
 
 def write_model_properties(
     path: str, model: Dict[str, Any], path_template: Dict[str, str]
-) -> NoReturn:
+) -> None:
     path_form = path.format(**path_template)
     model_path = Path(path_form)
     # It is a file and it exists

--- a/dbt_gloss/unify_column_description.py
+++ b/dbt_gloss/unify_column_description.py
@@ -1,7 +1,6 @@
 import argparse
 from collections import Counter
 from pathlib import Path
-from typing import NoReturn
 from typing import Optional
 from typing import Sequence
 
@@ -11,7 +10,7 @@ from dbt_gloss.check_column_desc_are_same import get_grouped
 from dbt_gloss.utils import add_filenames_args
 
 
-def _replace_desc(path: Path, column_name: str, description: str) -> NoReturn:
+def _replace_desc(path: Path, column_name: str, description: str) -> None:
     file = yaml.safe_load(path.open())
     for model in file.get("models", []):
         for column in model.get("columns", []):

--- a/dbt_gloss/utils.py
+++ b/dbt_gloss/utils.py
@@ -7,14 +7,13 @@ from typing import Any
 from typing import Dict
 from typing import Generator
 from typing import List
-from typing import NoReturn
 from typing import Optional
 from typing import Sequence
 from typing import Set
 from typing import Text
 from typing import Union
 
-import yaml
+from yaml import safe_load
 
 
 class CalledProcessError(RuntimeError):
@@ -171,7 +170,7 @@ def get_model_schemas(
     yml_files: Sequence[Path], filenames: Set[str], all_schemas: bool = False
 ) -> Generator[ModelSchema, None, None]:
     for yml_file in yml_files:
-        schema = yaml.safe_load(yml_file.open())
+        schema = safe_load(yml_file.open())
         for model in schema.get("models", []):
             if isinstance(model, dict) and model.get("name"):
                 model_name = model.get("name", "")  # pragma: no mutate
@@ -188,7 +187,7 @@ def get_macro_schemas(
     yml_files: Sequence[Path], filenames: Set[str], all_schemas: bool = False
 ) -> Generator[MacroSchema, None, None]:
     for yml_file in yml_files:
-        schema = yaml.safe_load(yml_file.open())
+        schema = safe_load(yml_file.open())
         for macro in schema.get("macros", []):
             if isinstance(macro, dict) and macro.get("name"):
                 macro_name = macro.get("name", "")  # pragma: no mutate
@@ -205,7 +204,7 @@ def get_source_schemas(
     yml_files: Sequence[Path],
 ) -> Generator[SourceSchema, None, None]:
     for yml_file in yml_files:
-        schema = yaml.safe_load(yml_file.open())
+        schema = safe_load(yml_file.open())
         for source in schema.get("sources", []):
             source_name = source.get("name")
             tables = source.pop("tables", [])
@@ -304,7 +303,7 @@ def run_dbt_cmd(cmd: Sequence[Any]) -> int:
     return status_code
 
 
-def add_filenames_args(parser: argparse.ArgumentParser) -> NoReturn:
+def add_filenames_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "filenames",
         nargs="*",
@@ -312,7 +311,7 @@ def add_filenames_args(parser: argparse.ArgumentParser) -> NoReturn:
     )
 
 
-def add_manifest_args(parser: argparse.ArgumentParser) -> NoReturn:
+def add_manifest_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--manifest",
         type=str,
@@ -323,7 +322,7 @@ def add_manifest_args(parser: argparse.ArgumentParser) -> NoReturn:
     )
 
 
-def add_catalog_args(parser: argparse.ArgumentParser) -> NoReturn:
+def add_catalog_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--catalog",
         type=str,
@@ -336,7 +335,7 @@ def add_catalog_args(parser: argparse.ArgumentParser) -> NoReturn:
     )
 
 
-def add_dbt_cmd_args(parser: argparse.ArgumentParser) -> NoReturn:
+def add_dbt_cmd_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--global-flags",
         nargs="*",
@@ -350,7 +349,7 @@ def add_dbt_cmd_args(parser: argparse.ArgumentParser) -> NoReturn:
     )
 
 
-def add_dbt_cmd_model_args(parser: argparse.ArgumentParser) -> NoReturn:
+def add_dbt_cmd_model_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--model-prefix",
         type=str,
@@ -381,7 +380,7 @@ class ParseDict(argparse.Action):  # pragma: no cover
         namespace: argparse.Namespace,
         values: Union[Text, Sequence[Any], None],
         option_string: Optional[str] = None,
-    ) -> NoReturn:
+    ) -> None:
         """Perform the parsing"""
         result = {}
 

--- a/tests/unit/test_check_column_name_contract.py
+++ b/tests/unit/test_check_column_name_contract.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_column_name_contract import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["aa/bb/with_boolean_column_with_prefix.sql"], "is_.*", "boolean", True, 0),

--- a/tests/unit/test_check_macro_arguments_have_desc.py
+++ b/tests/unit/test_check_macro_arguments_have_desc.py
@@ -3,7 +3,6 @@ import pytest
 from dbt_gloss.check_macro_arguments_have_desc import check_argument_desc
 from dbt_gloss.check_macro_arguments_have_desc import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["macros/aa/with_argument_description.sql"], True, 0),

--- a/tests/unit/test_check_macro_has_description.py
+++ b/tests/unit/test_check_macro_has_description.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_macro_has_description import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["macros/aa/with_description.sql"], True, 0),

--- a/tests/unit/test_check_model_columns_have_desc.py
+++ b/tests/unit/test_check_model_columns_have_desc.py
@@ -3,7 +3,6 @@ import pytest
 from dbt_gloss.check_model_columns_have_desc import check_column_desc
 from dbt_gloss.check_model_columns_have_desc import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["aa/bb/with_column_description.sql"], True, 0),

--- a/tests/unit/test_check_model_has_all_columns.py
+++ b/tests/unit/test_check_model_has_all_columns.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_has_all_columns import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["aa/bb/catalog_cols.sql"], True, True, 0),

--- a/tests/unit/test_check_model_has_description.py
+++ b/tests/unit/test_check_model_has_description.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_has_description import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["aa/bb/with_description.sql"], True, 0),

--- a/tests/unit/test_check_model_has_tests.py
+++ b/tests/unit/test_check_model_has_tests.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_has_tests import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (  # type: ignore

--- a/tests/unit/test_check_model_has_tests_by_group.py
+++ b/tests/unit/test_check_model_has_tests_by_group.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_has_tests_by_group import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (

--- a/tests/unit/test_check_model_has_tests_by_name.py
+++ b/tests/unit/test_check_model_has_tests_by_name.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_has_tests_by_name import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (

--- a/tests/unit/test_check_model_has_tests_by_type.py
+++ b/tests/unit/test_check_model_has_tests_by_type.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_has_tests_by_type import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (

--- a/tests/unit/test_check_model_name_contract.py
+++ b/tests/unit/test_check_model_name_contract.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_name_contract import main
 
-
 # Input args, valid manifest, expected return value
 TESTS = (
     (["aa/bb/catalog_cols.sql"], "catalog_.*", True, 0),

--- a/tests/unit/test_check_model_parents_and_childs.py
+++ b/tests/unit/test_check_model_parents_and_childs.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_parents_and_childs import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (  # type: ignore

--- a/tests/unit/test_check_model_parents_database.py
+++ b/tests/unit/test_check_model_parents_database.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_parents_database import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (  # type: ignore

--- a/tests/unit/test_check_model_parents_schema.py
+++ b/tests/unit/test_check_model_parents_schema.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_parents_schema import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (  # type: ignore

--- a/tests/unit/test_check_model_tags.py
+++ b/tests/unit/test_check_model_tags.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_model_tags import main
 
-
 TESTS = (
     (["aa/bb/with_tags.sql", "--tags", "foo", "bar"], True, 0),
     (["aa/bb/with_tags_foo.sql", "--tags", "foo", "bar"], True, 0),

--- a/tests/unit/test_check_script_has_no_table_name.py
+++ b/tests/unit/test_check_script_has_no_table_name.py
@@ -5,7 +5,6 @@ from dbt_gloss.check_script_has_no_table_name import main
 from dbt_gloss.check_script_has_no_table_name import prev_cur_next_iter
 from dbt_gloss.check_script_has_no_table_name import replace_comments
 
-
 # Input, args, expected return value, expected output
 TESTS = (  # type: ignore
     (

--- a/tests/unit/test_check_script_semicolon.py
+++ b/tests/unit/test_check_script_semicolon.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_script_semicolon import main
 
-
 # Input, expected return value
 TESTS = (
     (b"foo\n", 0),

--- a/tests/unit/test_check_source_childs.py
+++ b/tests/unit/test_check_source_childs.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_childs import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 # Input args, valid manifest, expected return value
 TESTS = (  # type: ignore

--- a/tests/unit/test_check_source_columns_have_desc.py
+++ b/tests/unit/test_check_source_columns_have_desc.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_columns_have_desc import main
 
-
 # Input schema, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_has_all_columns.py
+++ b/tests/unit/test_check_source_has_all_columns.py
@@ -3,7 +3,6 @@ import pytest
 from dbt_gloss.check_source_has_all_columns import get_catalog_nodes
 from dbt_gloss.check_source_has_all_columns import main
 
-
 # Input schema, valid_catalog, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_has_freshness import main
 
-
 # Input schema, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_has_loader.py
+++ b/tests/unit/test_check_source_has_loader.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_has_loader import main
 
-
 # Input schema, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_has_meta_keys.py
+++ b/tests/unit/test_check_source_has_meta_keys.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_has_meta_keys import main
 
-
 # Input schema, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_has_tests.py
+++ b/tests/unit/test_check_source_has_tests.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_has_tests import main
 
-
 # Input schema, valid_manifest, expected return value
 TESTS = (  # type: ignore
     (

--- a/tests/unit/test_check_source_has_tests_by_name.py
+++ b/tests/unit/test_check_source_has_tests_by_name.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_has_tests_by_name import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_has_tests_by_type.py
+++ b/tests/unit/test_check_source_has_tests_by_type.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_has_tests_by_type import main
 
-
 # Input schema, input_args, valid_manifest, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_table_has_description.py
+++ b/tests/unit/test_check_source_table_has_description.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_table_has_description import main
 
-
 # Input schema, expected return value
 TESTS = (
     (

--- a/tests/unit/test_check_source_tags.py
+++ b/tests/unit/test_check_source_tags.py
@@ -2,7 +2,6 @@ import pytest
 
 from dbt_gloss.check_source_tags import main
 
-
 # Input schema, expected return value
 TESTS = (
     (

--- a/tests/unit/test_remove_script_semicolon.py
+++ b/tests/unit/test_remove_script_semicolon.py
@@ -5,7 +5,6 @@ import pytest
 from dbt_gloss.check_script_semicolon import check_semicolon
 from dbt_gloss.remove_script_semicolon import main
 
-
 # Input, expected return value, expected output
 TESTS = (
     (b"foo\n", 0, b"foo\n"),

--- a/tests/unit/test_replace_script_table_names.py
+++ b/tests/unit/test_replace_script_table_names.py
@@ -3,7 +3,6 @@ import pytest
 from dbt_gloss.replace_script_table_names import get_source_from_name
 from dbt_gloss.replace_script_table_names import main
 
-
 # Input, expected return value, expected output
 TESTS = (  # type: ignore
     (

--- a/tests/unit/test_script_ref_and_source.py
+++ b/tests/unit/test_script_ref_and_source.py
@@ -4,7 +4,6 @@ from dbt_gloss.check_script_ref_and_source import check_refs_sources
 from dbt_gloss.check_script_ref_and_source import main
 from dbt_gloss.utils import get_json
 
-
 # Input, expected return value, expected output
 TESTS = (  # type: ignore
     (


### PR DESCRIPTION
Update the pre-commit-config file to use the latest dependencies, notably for black and, mirrors-mypy, and reorder_python_imports. 

Fix related stylistic changes to get pre-commit back in good shape. 