### PR TITLE
Feature/check id column is named

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,6 +10,12 @@
     entry: check-column-name-contract
     language: python
     types: [sql]
+-   id: check-id-column-is-named
+    name: Check `id` column is named
+    description: Check that there are no columns named `id`.
+    entry: check-id-column-is-named
+    language: python
+    types: [sql]
 -   id: check-macro-has-description
     name: Check the macro has description
     description: Ensures that the macro has description in properties file.

--- a/HOOKS.md
+++ b/HOOKS.md
@@ -7,6 +7,7 @@
 **Model checks:**
  * [`check-column-desc-are-same`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-column-desc-are-same): Check column descriptions are the same.
  * [`check-column-name-contract`](): Check column name abides to contract.
+ * [`check-id-column-is-named `](): Check that there are no columns named `id`.
  * [`check-model-columns-have-desc`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-model-columns-have-desc): Check the model columns have description.
  * [`check-model-has-all-columns`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-model-has-all-columns): Check the model has all columns in the properties file.
  * [`check-model-has-description`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-model-has-description): Check the model has description.
@@ -142,6 +143,42 @@ You want to make sure your columns follow a contract, e.g. all your boolean colu
 - The catalog is scanned for a model.
 - If any column in the found model matches the regex pattern and it's data type does not match the contract's data type, the hook fails.
 - If any column in the found model matches the contract's data type and does not match the regex pattern, the hook fails.
+
+
+-----
+### `check-id-column-is-named`
+
+Check that there are no columns named `id` as described in the [dbt Labs style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md#model-file-naming-and-coding).
+
+#### Example
+```
+repos:
+- repo: https://github.com/Montreal-Analytics/dbt-gloss
+ rev: v1.0.0
+ hooks:
+ - id: check-id-column-is-named
+```
+
+#### When to use it
+
+You want to make sure you don't have any columns simply named as `id`, it and should be named `<object>_id`,
+e.g. `account_id` – this makes it easier to know what id is being referenced in downstream joined models.
+
+#### Requirements
+
+| Model exists in `manifest.json` <sup id="a1">[1](#f1)</sup> | Model exists in `catalog.json` <sup id="a2">[2](#f2)</sup> |
+| :----: | :----------: |
+| :x: Not needed | :white_check_mark: Yes |
+
+<sup id="f1">1</sup> It means that you need to run `dbt run`, `dbt compile` before run this hook.<br/>
+<sup id="f2">2</sup> It means that you need to run `dbt docs generate` before run this hook.
+
+#### How it works
+
+- Hook takes all changed `SQL` files.
+- The model name is obtained from the `SQL` file name.
+- The catalog is scanned for a model.
+- If any column in the found model has a column named `id` (case insensitive), the hook fails.
 
 
 -----

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If this is the case, `dbt-gloss` is here to help you!
 **Model checks:**
  * [`check-column-desc-are-same`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-column-desc-are-same): Check column descriptions are the same.
  * [`check-column-name-contract`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-column-name-contract): Check column name abides to contract.
+ * [`check-id-column-is-named`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-id-column-is-named): Check that there are no columns named `id`.
  * [`check-model-columns-have-desc`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-model-columns-have-desc): Check the model columns have description.
  * [`check-model-has-all-columns`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-model-has-all-columns): Check the model has all columns in the properties file.
  * [`check-model-has-description`](https://github.com/Montreal-Analytics/dbt-gloss/blob/main/HOOKS.md#check-model-has-description): Check the model has description.

--- a/dbt_gloss/check_id_column_has_name.py
+++ b/dbt_gloss/check_id_column_has_name.py
@@ -1,0 +1,62 @@
+import argparse
+import re
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Sequence
+
+from dbt_gloss.utils import add_catalog_args
+from dbt_gloss.utils import add_filenames_args
+from dbt_gloss.utils import get_filenames
+from dbt_gloss.utils import get_json
+from dbt_gloss.utils import get_models
+from dbt_gloss.utils import JsonOpenError
+
+
+def check_id_column_has_name_contract(
+    paths: Sequence[str], catalog: Dict[str, Any]
+) -> int:
+    status_code = 0
+    sqls = get_filenames(paths, [".sql"])
+    filenames = set(sqls.keys())
+    models = get_models(catalog, filenames)
+
+    for model in models:
+        for col in model.node.get("columns", []).values():
+            col_name = col.get("name")
+            col_type = col.get("type")
+
+            # Check that no columns are called "ID".
+            # Enforces named ID column names
+            if col_name.upper() == "ID":
+                status_code = 1
+                print(
+                    f"{col_name}: column is of type {col_type} and "
+                    "does not have a named `id` column. Should "
+                    "name the column. E.g. `id` -> `name_me_id`"
+                )
+
+    return status_code
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser()
+    add_filenames_args(parser)
+    add_catalog_args(parser)
+
+    args = parser.parse_args(argv)
+
+    try:
+        catalog = get_json(args.catalog)
+    except JsonOpenError as e:
+        print(f"Unable to load catalog file ({e})")
+        return 1
+
+    return check_id_column_has_name_contract(
+        paths=args.filenames,
+        catalog=catalog,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/dbt_gloss/check_id_column_is_named.py
+++ b/dbt_gloss/check_id_column_is_named.py
@@ -13,7 +13,7 @@ from dbt_gloss.utils import get_models
 from dbt_gloss.utils import JsonOpenError
 
 
-def check_id_column_is_named_contract(
+def check_id_column_is_named(
     paths: Sequence[str], catalog: Dict[str, Any]
 ) -> int:
     status_code = 0
@@ -52,7 +52,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"Unable to load catalog file ({e})")
         return 1
 
-    return check_id_column_is_named_contract(
+    return check_id_column_is_named(
         paths=args.filenames,
         catalog=catalog,
     )

--- a/dbt_gloss/check_id_column_is_named.py
+++ b/dbt_gloss/check_id_column_is_named.py
@@ -13,7 +13,7 @@ from dbt_gloss.utils import get_models
 from dbt_gloss.utils import JsonOpenError
 
 
-def check_id_column_has_name_contract(
+def check_id_column_is_named_contract(
     paths: Sequence[str], catalog: Dict[str, Any]
 ) -> int:
     status_code = 0
@@ -52,7 +52,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"Unable to load catalog file ({e})")
         return 1
 
-    return check_id_column_has_name_contract(
+    return check_id_column_is_named_contract(
         paths=args.filenames,
         catalog=catalog,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ python_requires = >=3.7.1
 console_scripts =
     check-column-desc-are-same = dbt_gloss.check_column_desc_are_same:main
     check-column-name-contract = dbt_gloss.check_column_name_contract:main
+    check-id-column-is-named = dbt_gloss.check_id_column_is_named:main
     check-macro-has-description = dbt_gloss.check_macro_has_description:main
     check-macro-arguments-have-desc = dbt_gloss.check_macro_arguments_have_desc:main
     check-model-columns-have-desc = dbt_gloss.check_model_columns_have_desc:main

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -251,6 +251,20 @@ CATALOG = {
                 "COL2": {"type": "TEXT", "name": "COL2"},
             },
         },
+        "model.test.id_column_is_named": {
+            "metadata": {},
+            "columns": {
+                "ACCOUNT_ID": {"type": "TEXT", "name": "ACCOUNT_ID"},
+                "COL2": {"type": "TEXT", "name": "COL2"},
+            },
+        },
+        "model.test.id_column_is_not_named": {
+            "metadata": {},
+            "columns": {
+                "ID": {"type": "TEXT", "name": "ID"},
+                "COL2": {"type": "TEXT", "name": "COL2"},
+            },
+        },
     },
     "sources": {
         "source.test.ff.with_catalog_columns": {},

--- a/tests/unit/test_check_id_column_is_named.py
+++ b/tests/unit/test_check_id_column_is_named.py
@@ -1,0 +1,22 @@
+import pytest
+
+from dbt_gloss.check_id_column_is_named import main
+
+# Input args, valid manifest, expected return value
+TESTS = (
+    (["aa/bb/id_column_is_named.sql"], True, 0),
+    (["aa/bb/id_column_is_named.sql"], False, 1),
+    (["aa/bb/id_column_is_not_named.sql"], True, 1),
+)
+
+
+@pytest.mark.parametrize(
+    ("input_args", "valid_catalog", "expected_status_code"), TESTS
+)
+def test_check_id_column_is_named(
+    input_args, valid_catalog, expected_status_code, catalog_path_str
+):
+    if valid_catalog:
+        input_args.extend(["--catalog", catalog_path_str])
+    status_code = main(input_args)
+    assert status_code == expected_status_code


### PR DESCRIPTION
Contribution of extra check to ensure there are no columns named `id` as per dbt Labs style guide:
https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md#model-file-naming-and-coding

> Should be named `<object>_id`, e.g. `account_id` – this makes it easier to know what id is being referenced in downstream joined models.

This is not currently possible to do with the `check-column-name-contract` implementation.