### PR TITLE
fix: Source freshness errors with optional filter arg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
       - id: name-tests-test
         args: ['--django']
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/dbt_gloss/check_source_has_freshness.py
+++ b/dbt_gloss/check_source_has_freshness.py
@@ -19,6 +19,8 @@ def has_freshness(paths: Sequence[str], required_freshness: Set[str]) -> int:
         source = schema.source_schema
         table = schema.table_schema
         merged = {**source.get("freshness", {}), **table.get("freshness", {})}
+        if "filter" in merged.keys():
+            merged.pop("filter")
         freshness = {
             key
             for key, value in merged.items()

--- a/tests/unit/test_check_source_has_freshness.py
+++ b/tests/unit/test_check_source_has_freshness.py
@@ -108,6 +108,21 @@ sources:
     """,
         1,
     ),
+    (
+        """
+sources:
+-   name: test
+    tables:
+    -   name: with_description
+        loaded_at_field: aa
+        freshness:
+            warn_after:
+                count: 12
+                period: hour
+            filter: 'test'
+    """,
+        1,
+    ),
 )
 
 


### PR DESCRIPTION
Description
---
When using optional freshness argument [`filter`](https://docs.getdbt.com/reference/resource-properties/freshness#filter) the hook `check_source_has_freshness.py` returns the following error:

```AttributeError: 'str' object has no attribute 'keys'```

It happens because the hook is expecting dictionaries (warn_after and error_after), but filter is a string.
A simple fix is to pop the key if it exists before checking for required keys as I did in the PR.

Obs: I had to change github flake8 pre-commit hook from gitlab to github because I don't have a gitlab acc, feel free to change back to gitlab if you guys think it's necessary.

Testing
---
```pytest tests/unit/test_check_source_has_freshness.py```
